### PR TITLE
Builtin version

### DIFF
--- a/src/saml2/xml_util.py
+++ b/src/saml2/xml_util.py
@@ -1,13 +1,15 @@
+import xml.etree.ElementTree as ET
+
+
 def replace_retrieval_method(xmlstr):
     """
     Given an XML string, replace entries of RetrievalMethod with the referred
     content. Used to support EncryptedKey retrieval method for KeyInfo in
     encrypted assertions.
     """
-    from lxml import etree
-    root = etree.fromstring(xmlstr)
-    ds_ns = root.nsmap.get('ds', 'http://www.w3.org/2000/09/xmldsig#')
-    xenc_ns = root.nsmap.get('xenc', 'http://www.w3.org/2001/04/xmlenc#')
+    root = ET.fromstring(xmlstr)
+    ds_ns = 'http://www.w3.org/2000/09/xmldsig#'
+    xenc_ns = 'http://www.w3.org/2001/04/xmlenc#'
     retrieval_methods = root.findall('.//{{{}}}RetrievalMethod'.format(ds_ns))
     replacements = []
     for retmet in retrieval_methods:
@@ -26,7 +28,15 @@ def replace_retrieval_method(xmlstr):
             # Unsupported
             continue
         replacements.append((retmet, encrypted_key[0]))
+
+    parent_map = {c: p for p in root.iter() for c in p}
     for old, new in replacements:
-        parent = old.getparent()
-        parent.replace(old, new)
-    return etree.tostring(root)
+        parent = parent_map[old]
+        parent_index = list(parent).index(old)
+        parent.remove(old)
+        parent.insert(parent_index, new)
+    # now remove the referenced keys from the original position
+    for _, new in replacements:
+        parent = parent_map[new]
+        parent.remove(new)
+    return ET.tostring(root)


### PR DESCRIPTION
This replaces the `replace_retrieval_method` function to use the python builtin `etree` library instead of `lxml` for portability.

Test with Okta integration to see if it still works.